### PR TITLE
[FIX] org.apache.commons.lang3 삭제로 인해 발생한 오류 수정

### DIFF
--- a/src/main/java/com/connect/accountApp/domain/household/application/service/RegisterHouseholdService.java
+++ b/src/main/java/com/connect/accountApp/domain/household/application/service/RegisterHouseholdService.java
@@ -10,7 +10,6 @@ import com.connect.accountApp.domain.user.domain.model.User;
 import java.math.BigDecimal;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.stereotype.Service;
 
 @Service


### PR DESCRIPTION
 - org.apache.commons.lang3.RandomStringUtils 임포트 삭제